### PR TITLE
Add an option for setting the chart baseline to 0

### DIFF
--- a/components/IssueTracker.js
+++ b/components/IssueTracker.js
@@ -42,6 +42,7 @@ const IssueTracker = ({
                   dateKey="inserted_at"
                   valueKey="open_issues"
                   xLabel="Open issues"
+                  showBaselineToggle={true}
                 />
               </div>
               <div className="sm:px-10 w-full mt-10 flex flex-col">

--- a/components/TimelineChart.js
+++ b/components/TimelineChart.js
@@ -1,9 +1,15 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import Toggle from './toggle'
 
 // Need two more properties: dateKey, valueKey
 
 const TimelineChart = ({ id, uPlot, data, dateKey, valueKey, xLabel = '' }) => {
   const dataPlotRef = useRef(null)
+  const [isBaselineZero, setIsBaselineZero] = useState(false)
+
+  const handleToggle = () => {
+    setIsBaselineZero(!isBaselineZero)
+  }
 
   useEffect(() => {
     if (data.length > 0) {
@@ -15,13 +21,19 @@ const TimelineChart = ({ id, uPlot, data, dateKey, valueKey, xLabel = '' }) => {
         chartData[0].push(Math.floor(new Date(issue[dateKey]) / 1000))
         chartData[1].push(issue[valueKey])
       })
-      dataPlotRef.current?.setData(chartData)
-      // dataPlotRef.current?.setScale('y', {
-      //   min: 0,
-      //   max: Math.max(...data.map(issue => issue[valueKey]))
-      // })
+      // We need to pass true as the second argument of setData
+      // in order to reset the scale.
+      dataPlotRef.current?.setData(chartData, true)
+
+      if (isBaselineZero) {
+        dataPlotRef.current?.setScale('y', {
+          min: 0,
+          max: Math.max(...data.map(issue => issue[valueKey]))
+        })
+      }
+      
     }
-  }, [data])
+  }, [data, isBaselineZero])
 
   useEffect(() => {
     if (dataPlotRef.current === null) {
@@ -103,9 +115,14 @@ const TimelineChart = ({ id, uPlot, data, dateKey, valueKey, xLabel = '' }) => {
   }, [])
   
   return (
-    <div className="text-white">
-      <div id={id} className="w-full h-60 sm:h-80" />
-    </div>
+    <>
+      <div className="float-right transform -translate-x-10 translate-y-4">
+        <Toggle isOn={isBaselineZero} onToggle={handleToggle}/>
+      </div>
+      <div className="text-white clear-both">
+        <div id={id} className="w-full h-60 sm:h-80" />
+      </div>
+    </>
   )
 }
 

--- a/components/TimelineChart.js
+++ b/components/TimelineChart.js
@@ -1,9 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
-import Toggle from './toggle'
+import Toggle from 'components/Toggle'
 
-// Need two more properties: dateKey, valueKey
-
-const TimelineChart = ({ id, uPlot, data, dateKey, valueKey, xLabel = '' }) => {
+const TimelineChart = ({
+  id,
+  uPlot,
+  data,
+  dateKey,
+  valueKey,
+  xLabel = '',
+  showBaselineToggle = false,
+}) => {
   const dataPlotRef = useRef(null)
   const [isBaselineZero, setIsBaselineZero] = useState(false)
 
@@ -116,9 +122,11 @@ const TimelineChart = ({ id, uPlot, data, dateKey, valueKey, xLabel = '' }) => {
   
   return (
     <>
-      <div className="float-right transform -translate-x-10 translate-y-4">
-        <Toggle isOn={isBaselineZero} onToggle={handleToggle}/>
-      </div>
+      {showBaselineToggle && (
+        <div className="sm:px-10">
+          <Toggle isOn={isBaselineZero} onToggle={handleToggle} label="Set baseline to 0" />
+        </div>
+      )}
       <div className="text-white clear-both">
         <div id={id} className="w-full h-60 sm:h-80" />
       </div>

--- a/components/Toggle.js
+++ b/components/Toggle.js
@@ -1,0 +1,51 @@
+const sizes = {
+    md: {
+      slider: 'h-5 w-5',
+      toggleOn: 'translate-x-5',
+      toggleOff: 'translate-x-0',
+      background: 'h-6 w-11 border-2',
+    },
+    sm: {
+      slider: 'h-4 w-4',
+      toggleOn: 'translate-x-5',
+      toggleOff: 'translate-x-1',
+      background: 'h-5 w-10 border-1',
+    },
+    xsm: {
+        slider: 'h-3 w-3',
+        toggleOn: 'translate-x-3.5 -translate-y-1',
+        toggleOff: 'translate-x-0.5 -translate-y-1',
+        background: 'h-3.5 w-7 border-1',
+    },
+  }
+  
+  export default function Toggle({
+    onToggle = () => {},
+    isOn = false,
+    size = 'xsm',
+    isDisabled = false,
+  }) {
+    const toggleSizes = sizes[size]
+    return (
+      <>
+        <span
+            role="checkbox"
+            aria-checked="false"
+            onClick={!isDisabled ? onToggle : () => {}}
+            className={`${isOn ? 'bg-green-500' : 'bg-gray-200'} ${toggleSizes.background} ${
+            isDisabled ? 'cursor-not-allowed' : 'cursor-pointer'
+            } relative inline-block flex-shrink-0 border-transparent rounded-full transition-colors ease-in-out duration-200 focus:outline-none focus:ring `}
+        >
+            <span
+            aria-hidden="true"
+            className={`${isOn ? toggleSizes.toggleOn : toggleSizes.toggleOff} ${
+                isDisabled ? 'cursor-not-allowed bg-white' : 'cursor-pointer bg-white'
+            }  ${
+                toggleSizes.slider
+            } inline-block rounded-full shadow transform transition ease-in-out duration-200`}
+            ></span>
+        </span>
+        <span className='text-base inline-block transform translate-x-1 -translate-y-1 text-gray-400'>Set baseline to 0</span>
+      </>
+    )
+  }

--- a/components/Toggle.js
+++ b/components/Toggle.js
@@ -1,51 +1,54 @@
 const sizes = {
-    md: {
-      slider: 'h-5 w-5',
-      toggleOn: 'translate-x-5',
-      toggleOff: 'translate-x-0',
-      background: 'h-6 w-11 border-2',
-    },
-    sm: {
-      slider: 'h-4 w-4',
-      toggleOn: 'translate-x-5',
-      toggleOff: 'translate-x-1',
-      background: 'h-5 w-10 border-1',
-    },
-    xsm: {
-        slider: 'h-3 w-3',
-        toggleOn: 'translate-x-3.5 -translate-y-1',
-        toggleOff: 'translate-x-0.5 -translate-y-1',
-        background: 'h-3.5 w-7 border-1',
-    },
-  }
-  
-  export default function Toggle({
-    onToggle = () => {},
-    isOn = false,
-    size = 'xsm',
-    isDisabled = false,
-  }) {
-    const toggleSizes = sizes[size]
-    return (
-      <>
-        <span
-            role="checkbox"
-            aria-checked="false"
-            onClick={!isDisabled ? onToggle : () => {}}
-            className={`${isOn ? 'bg-green-500' : 'bg-gray-200'} ${toggleSizes.background} ${
-            isDisabled ? 'cursor-not-allowed' : 'cursor-pointer'
-            } relative inline-block flex-shrink-0 border-transparent rounded-full transition-colors ease-in-out duration-200 focus:outline-none focus:ring `}
-        >
-            <span
-            aria-hidden="true"
-            className={`${isOn ? toggleSizes.toggleOn : toggleSizes.toggleOff} ${
-                isDisabled ? 'cursor-not-allowed bg-white' : 'cursor-pointer bg-white'
-            }  ${
-                toggleSizes.slider
-            } inline-block rounded-full shadow transform transition ease-in-out duration-200`}
-            ></span>
-        </span>
-        <span className='text-base inline-block transform translate-x-1 -translate-y-1 text-gray-400'>Set baseline to 0</span>
-      </>
-    )
-  }
+  md: {
+    slider: 'h-5 w-5',
+    toggleOn: 'translate-x-5',
+    toggleOff: 'translate-x-0',
+    background: 'h-6 w-11 border-2',
+  },
+  sm: {
+    slider: 'h-4 w-4',
+    toggleOn: 'translate-x-5',
+    toggleOff: 'translate-x-1',
+    background: 'h-5 w-10 border-1',
+  },
+  xsm: {
+      slider: 'h-3 w-3',
+      toggleOn: 'translate-x-3.5 -translate-y-1',
+      toggleOff: 'translate-x-0.5 -translate-y-1',
+      background: 'h-4 w-7 border-1',
+  },
+}
+
+const Toggle = ({
+  onToggle = () => {},
+  label = '',
+  isOn = false,
+  size = 'xsm',
+  isDisabled = false,
+}) => {
+  const toggleSizes = sizes[size]
+  return (
+    <>
+      <span
+          role="checkbox"
+          aria-checked="false"
+          onClick={!isDisabled ? onToggle : () => {}}
+          className={`${isOn ? 'bg-green-500' : 'bg-gray-200'} ${toggleSizes.background} ${
+          isDisabled ? 'cursor-not-allowed' : 'cursor-pointer'
+          } relative inline-block flex-shrink-0 border-transparent rounded-full transition-colors ease-in-out duration-200 focus:outline-none focus:ring `}
+      >
+          <span
+          aria-hidden="true"
+          className={`${isOn ? toggleSizes.toggleOn : toggleSizes.toggleOff} ${
+              isDisabled ? 'cursor-not-allowed bg-white' : 'cursor-pointer bg-white'
+          }  ${
+              toggleSizes.slider
+          } inline-block rounded-full shadow transform transition ease-in-out duration-200`}
+          ></span>
+      </span>
+      <span className='text-sm inline-block ml-2 transform translate-x-1 -translate-y-1 text-gray-400'>{label}</span>
+    </>
+  )
+}
+
+export default Toggle

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -51,6 +51,7 @@ const OrganizationOverview = ({ supabase, organization, repoNames }) => {
             dateKey="inserted_at"
             valueKey="open_issues"
             xLabel="Open issues"
+            showBaselineToggle={true}
           />
         </div>
       </div>


### PR DESCRIPTION
This PR will add a toggle button for setting the baseline to 0.

Personally, I think it's important to be able to switch between a higher baseline and the zero baseline. Maybe the reason I find it important is just because of my stats background.

Also, I took most of the JS code for the toggle button from our infra code - I hope that's okay?

---

### Screenshots:

Higher baseline (gives us a better idea about the movement):
<img width="1143" alt="higher baseline" src="https://user-images.githubusercontent.com/1811651/102981596-0a2b0a80-44be-11eb-813d-5f31d7881a92.png">

0 baseline (gives us a better idea about the overall picture):
<img width="1141" alt="0 baseline" src="https://user-images.githubusercontent.com/1811651/102981589-07c8b080-44be-11eb-9f40-f9f0d5af7585.png">
